### PR TITLE
記事のファイル名にtitleオプションを追加

### DIFF
--- a/cli/gen_article/README.md
+++ b/cli/gen_article/README.md
@@ -43,7 +43,7 @@ dart run bin/gen_article.dart \
 
 ### 出力先
 
-記事は `articles/YYYY/MM/YYYY-MM-DD.md` の形式で保存されます。
+記事は `articles/YYYY/MM/YYYY-MM-DD_title.md` の形式で保存されます。
 
 ### テンプレート
 

--- a/cli/gen_article/lib/gen_article.dart
+++ b/cli/gen_article/lib/gen_article.dart
@@ -50,7 +50,7 @@ Future<void> generateArticle({
   }
 
   // ファイル名の作成
-  final fileName = '$year-$month-$day.md';
+  final fileName = '$year-$month-${day}_$title.md';
 
   // 出力ファイルのパス
   final outputPath = path.join(outputDir, fileName);


### PR DESCRIPTION
This pull request includes changes to the `cli/gen_article` module to modify the file naming convention for generated articles. The changes ensure that the title is included in the filename.

Changes to file naming convention:

* [`cli/gen_article/README.md`](diffhunk://#diff-3a195e7b89de4c35c52a091e0893b52e403073cd911f535d55633482f9dbf116L46-R46): Updated the documentation to reflect the new file naming format `articles/YYYY/MM/YYYY-MM-DD_title.md`.
* [`cli/gen_article/lib/gen_article.dart`](diffhunk://#diff-1d5c2e607c2650f17143a964d9cfec42306ccd32f3a8a26d7f2ee9398d38b883L53-R53): Modified the `generateArticle` function to include the title in the generated file name.