### PR TITLE
URL入力時のエラーハンドリングを実装

### DIFF
--- a/app/article_viewer/lib/routing/ext_route.dart
+++ b/app/article_viewer/lib/routing/ext_route.dart
@@ -1,0 +1,53 @@
+extension ExtString on String {
+  /// 全角数字を半角数字に変換します。
+  /// 数字以外の文字が含まれている場合、[FormatException]を[throw]します。
+  String convertFullWidthToHalfWidth() {
+    final buffer = StringBuffer();
+
+    for (var i = 0; i < length; i++) {
+      final char = this[i];
+      final codeUnit = char.codeUnitAt(0);
+
+      // 全角数字（0xFF10-0xFF19）を半角（0x30-0x39）に変換
+      if (codeUnit >= 0xFF10 && codeUnit <= 0xFF19) {
+        buffer.write(String.fromCharCode(codeUnit - 0xFEE0));
+      } else if (codeUnit >= 0x30 && codeUnit <= 0x39) {
+        // 既に半角数字の場合はそのまま
+        buffer.write(char);
+      } else {
+        // 数字以外の文字が含まれている場合
+        throw FormatException('$this: $char is not a number');
+      }
+    }
+
+    return buffer.toString();
+  }
+}
+
+extension ExtUri on Uri {
+  /// 全角数字が含まれているかどうかを判定
+  bool containsFullWidthDigits() {
+    for (final segment in pathSegments) {
+      for (var i = 0; i < segment.length; i++) {
+        final codeUnit = segment.codeUnitAt(i);
+        // 全角数字（０-９）の範囲チェック（0xFF10-0xFF19）
+        if (codeUnit >= 0xFF10 && codeUnit <= 0xFF19) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /// 全角数字を半角数字に変換し、パスセグメントを返します。
+  List<String> pathSegmentsFullWidthToHalfWidth() {
+    return pathSegments.map((segment) {
+      try {
+        // segmentが全て数字の場合は半角数字に変換
+        return segment.convertFullWidthToHalfWidth();
+      } on FormatException {
+        return segment;
+      }
+    }).toList();
+  }
+}

--- a/app/article_viewer/lib/routing/router.dart
+++ b/app/article_viewer/lib/routing/router.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import '../ui/article/widgets/article_content_screen.dart';
 import '../ui/article/widgets/article_list_screen.dart';
+import '../ui/core/ui/not_found_screen.dart';
 
 part 'router.g.dart';
 
@@ -17,10 +18,14 @@ GoRouter router(Ref ref) {
     initialLocation: '/',
     redirect: (context, state) {
       // NOTE: ルートディレクトリを決めていないため、一旦/articlesにリダイレクト
-      if (!state.uri.path.startsWith('/articles')) {
+      if (state.uri.path == '/') {
         return '/articles';
       }
+
       return null;
+    },
+    errorBuilder: (context, state) {
+      return const NotFoundRoute().build(context, state);
     },
     debugLogDiagnostics: kDebugMode,
   );
@@ -84,5 +89,15 @@ class MarkdownRoute extends GoRouteData {
     final path = '$year/${DateFormat('MM').format(DateTime(0, month))}/$fileName';
 
     return ArticleContentScreen(path: path);
+  }
+}
+
+@TypedGoRoute<NotFoundRoute>(path: '/not-found')
+class NotFoundRoute extends GoRouteData {
+  const NotFoundRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const NotFoundScreen();
   }
 }

--- a/app/article_viewer/lib/routing/router.dart
+++ b/app/article_viewer/lib/routing/router.dart
@@ -20,7 +20,7 @@ GoRouter router(Ref ref) {
     redirect: (context, state) {
       // NOTE: ルートディレクトリを決めていないため、一旦/articlesにリダイレクト
       if (state.uri.path == '/') {
-        return ArticlesRoute().location;
+        return const ArticlesRoute().location;
       }
 
       // pathに全角数字が含まれている場合、半角数字に変換
@@ -69,12 +69,6 @@ class ArticlesYearRoute extends GoRouteData {
   Widget build(BuildContext context, GoRouterState state) {
     return ArticleListScreen(year: year);
   }
-
-  @override
-  String? redirect(BuildContext context, GoRouterState state) {
-    final path = ArticlesRoute().location;
-    return '$path/$year';
-  }
 }
 
 class ArticlesMonthRoute extends GoRouteData {
@@ -86,6 +80,15 @@ class ArticlesMonthRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return ArticleListScreen(year: year, month: month);
+  }
+
+  @override
+  String? redirect(BuildContext context, GoRouterState state) {
+    if (month < 1 || month > 12) {
+      return const NotFoundRoute().location;
+    }
+
+    return null;
   }
 }
 

--- a/app/article_viewer/lib/routing/router.dart
+++ b/app/article_viewer/lib/routing/router.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'ext_route.dart';
 import '../ui/article/widgets/article_content_screen.dart';
 import '../ui/article/widgets/article_list_screen.dart';
 import '../ui/core/ui/not_found_screen.dart';
@@ -19,7 +20,12 @@ GoRouter router(Ref ref) {
     redirect: (context, state) {
       // NOTE: ルートディレクトリを決めていないため、一旦/articlesにリダイレクト
       if (state.uri.path == '/') {
-        return '/articles';
+        return ArticlesRoute().location;
+      }
+
+      // pathに全角数字が含まれている場合、半角数字に変換
+      if (state.uri.containsFullWidthDigits()) {
+        return '/${state.uri.pathSegmentsFullWidthToHalfWidth().join('/')}';
       }
 
       return null;
@@ -62,6 +68,12 @@ class ArticlesYearRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return ArticleListScreen(year: year);
+  }
+
+  @override
+  String? redirect(BuildContext context, GoRouterState state) {
+    final path = ArticlesRoute().location;
+    return '$path/$year';
   }
 }
 

--- a/app/article_viewer/lib/routing/router.dart
+++ b/app/article_viewer/lib/routing/router.dart
@@ -58,6 +58,20 @@ class ArticlesRoute extends GoRouteData {
   Widget build(BuildContext context, GoRouterState state) {
     return const ArticleListScreen();
   }
+
+  @override
+  String? redirect(BuildContext context, GoRouterState state) {
+    for (final parameter in state.pathParameters.entries) {
+      switch (parameter.key) {
+        case 'year' when int.tryParse(parameter.value) == null:
+          return const NotFoundRoute().location;
+        case 'month' when int.tryParse(parameter.value) == null:
+          return const NotFoundRoute().location;
+      }
+    }
+
+    return null;
+  }
 }
 
 class ArticlesYearRoute extends GoRouteData {

--- a/app/article_viewer/lib/routing/router.g.dart
+++ b/app/article_viewer/lib/routing/router.g.dart
@@ -6,7 +6,7 @@ part of 'router.dart';
 // GoRouterGenerator
 // **************************************************************************
 
-List<RouteBase> get $appRoutes => [$articlesRoute];
+List<RouteBase> get $appRoutes => [$articlesRoute, $notFoundRoute];
 
 RouteBase get $articlesRoute => GoRouteData.$route(
   path: '/articles',
@@ -110,11 +110,32 @@ extension $MarkdownRouteExtension on MarkdownRoute {
   void replace(BuildContext context) => context.replace(location);
 }
 
+RouteBase get $notFoundRoute => GoRouteData.$route(
+  path: '/not-found',
+
+  factory: $NotFoundRouteExtension._fromState,
+);
+
+extension $NotFoundRouteExtension on NotFoundRoute {
+  static NotFoundRoute _fromState(GoRouterState state) => const NotFoundRoute();
+
+  String get location => GoRouteData.$location('/not-found');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'd60f0b22c24f5ba36e1a7f91526bbdc2c361a429';
+String _$routerHash() => r'22221a3e9472c5a99c34c4da2f9c4b07bfa7d607';
 
 /// See also [router].
 @ProviderFor(router)

--- a/app/article_viewer/lib/routing/router.g.dart
+++ b/app/article_viewer/lib/routing/router.g.dart
@@ -135,7 +135,7 @@ extension $NotFoundRouteExtension on NotFoundRoute {
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'724b2e499360e00730546f9d89e2052a1d77f482';
+String _$routerHash() => r'3151770a0cfef084dc2e6838d939b5d373d8d907';
 
 /// See also [router].
 @ProviderFor(router)

--- a/app/article_viewer/lib/routing/router.g.dart
+++ b/app/article_viewer/lib/routing/router.g.dart
@@ -135,7 +135,7 @@ extension $NotFoundRouteExtension on NotFoundRoute {
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'22221a3e9472c5a99c34c4da2f9c4b07bfa7d607';
+String _$routerHash() => r'724b2e499360e00730546f9d89e2052a1d77f482';
 
 /// See also [router].
 @ProviderFor(router)

--- a/app/article_viewer/lib/ui/core/ui/not_found_screen.dart
+++ b/app/article_viewer/lib/ui/core/ui/not_found_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'home_back_button.dart';
+
+class NotFoundScreen extends StatelessWidget {
+  const NotFoundScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          spacing: 20.0,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              '404',
+              style: TextStyle(fontSize: 80, fontWeight: FontWeight.bold, color: Colors.blueGrey),
+            ),
+
+            const Text(
+              'ページが見つかりません',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.w500, color: Colors.black87),
+            ),
+
+            const Text(
+              'お探しのページは存在しないか、移動した可能性があります。',
+              style: TextStyle(fontSize: 16, color: Colors.black54),
+              textAlign: TextAlign.center,
+            ),
+            const Padding(padding: EdgeInsets.symmetric(vertical: 16.0), child: HomeBackButton()),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- `articles/:year/:moth`の`:year`と`:month`に全角数字が入力されている場合、半角に変換しリダイレクト設定
- 意図しないパスを入力した時、NotFoundページにリダイレクト

This pull request introduces several changes to improve routing and error handling in the `app/article_viewer` module. The most important changes include adding extensions for string and URI manipulation, updating the router to handle full-width digits and not-found routes, and creating a new `NotFoundScreen` for better user experience.

### Routing Enhancements:

* [`app/article_viewer/lib/routing/ext_route.dart`](diffhunk://#diff-0ed14fc8f59882034b5da97484e82fe81f57f7d3d8b406f7262d0b038a22d1d1R1-R53): Added extensions `ExtString` and `ExtUri` to convert full-width digits to half-width and check for full-width digits in URIs.
* [`app/article_viewer/lib/routing/router.dart`](diffhunk://#diff-e5b1f5c16b6eb29e9caed991e625249f1bfb5f1be1b4ec66fccddd66a706a177R8-R11): Updated the router to handle full-width digits in paths and redirect to a not-found route when necessary. Added error handling to display the `NotFoundScreen`. [[1]](diffhunk://#diff-e5b1f5c16b6eb29e9caed991e625249f1bfb5f1be1b4ec66fccddd66a706a177R8-R11) [[2]](diffhunk://#diff-e5b1f5c16b6eb29e9caed991e625249f1bfb5f1be1b4ec66fccddd66a706a177L20-R35) [[3]](diffhunk://#diff-e5b1f5c16b6eb29e9caed991e625249f1bfb5f1be1b4ec66fccddd66a706a177R61-R74) [[4]](diffhunk://#diff-e5b1f5c16b6eb29e9caed991e625249f1bfb5f1be1b4ec66fccddd66a706a177R98-R106) [[5]](diffhunk://#diff-e5b1f5c16b6eb29e9caed991e625249f1bfb5f1be1b4ec66fccddd66a706a177R123-R132)
* [`app/article_viewer/lib/routing/router.g.dart`](diffhunk://#diff-893ed6f896c68feeb5480e77aa573c8351fa2a717a18803d6d45d7123e761276L9-R9): Updated generated routes to include the new not-found route. [[1]](diffhunk://#diff-893ed6f896c68feeb5480e77aa573c8351fa2a717a18803d6d45d7123e761276L9-R9) [[2]](diffhunk://#diff-893ed6f896c68feeb5480e77aa573c8351fa2a717a18803d6d45d7123e761276R113-R138)

### User Experience Improvements:

* [`app/article_viewer/lib/ui/core/ui/not_found_screen.dart`](diffhunk://#diff-00ebc8fc38573b8a044663e86df2d478851393bb7193a547a88e649ec6b24ea0R1-R36): Created a new `NotFoundScreen` to display a user-friendly 404 error message when a page is not found.