### PR TITLE
index.jsonからloadするようにリファクタリング

### DIFF
--- a/app/article_viewer/lib/data/repositories/article/article_meta_repository.dart
+++ b/app/article_viewer/lib/data/repositories/article/article_meta_repository.dart
@@ -21,13 +21,13 @@ class ArticleMetaRepository {
   Future<List<ArticleMeta>> getAll() async {
     final index = await rootBundle.loadString('$assetsMetaPath/index.json');
     final indexFile = IndexFile.fromJson(json.decode(index));
-    final yearIndexPaths = indexFile.indexes.map((e) => e.path).toList();
+    final yearIndexPaths = indexFile.indexes.map((e) => e.path);
 
     return Future.wait(
       yearIndexPaths.map((path) async {
         final jsonString = await rootBundle.loadString('$assetsMetaPath/$path');
         return ArticleMeta.fromJson(json.decode(jsonString));
-      }),
+      }).toList(),
     );
   }
 

--- a/app/article_viewer/lib/data/repositories/article/article_meta_repository.dart
+++ b/app/article_viewer/lib/data/repositories/article/article_meta_repository.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:article_models/article_models.dart';
 import 'package:article_viewer/domain/models/article.dart';
 
 part 'article_meta_repository.g.dart';
@@ -18,12 +19,13 @@ class ArticleMetaRepository {
   final String assetsMetaPath;
 
   Future<List<ArticleMeta>> getAll() async {
-    final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+    final index = await rootBundle.loadString('$assetsMetaPath/index.json');
+    final indexFile = IndexFile.fromJson(json.decode(index));
+    final yearIndexPaths = indexFile.indexes.map((e) => e.path).toList();
 
-    final metaFiles = manifest.listAssets().where((e) => e.startsWith(assetsMetaPath)).toList();
     return Future.wait(
-      metaFiles.map((path) async {
-        final jsonString = await rootBundle.loadString(path);
+      yearIndexPaths.map((path) async {
+        final jsonString = await rootBundle.loadString('$assetsMetaPath/$path');
         return ArticleMeta.fromJson(json.decode(jsonString));
       }),
     );

--- a/app/article_viewer/pubspec.lock
+++ b/app/article_viewer/pubspec.lock
@@ -33,6 +33,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
+  article_models:
+    dependency: "direct main"
+    description:
+      path: "../../packages/article_models"
+      relative: true
+    source: path
+    version: "1.0.0"
   async:
     dependency: transitive
     description:

--- a/app/article_viewer/pubspec.yaml
+++ b/app/article_viewer/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
 
   cupertino_icons: ^1.0.8
 
+  article_models:
+    path: ../../packages/article_models
+
   # state management
   flutter_riverpod: ^2.6.1
   riverpod_annotation: ^2.6.1


### PR DESCRIPTION
This pull request includes changes to the `article_meta_repository.dart` and `pubspec.yaml` files to improve the handling of article metadata by utilizing a new `IndexFile` structure and adding a dependency on the `article_models` package.

Improvements to article metadata handling:

* [`app/article_viewer/lib/data/repositories/article/article_meta_repository.dart`](diffhunk://#diff-1d1b6163ab55249553000ca96fc7bbcb562a2da07bcd1c13902f271a43ad01caL21-R28): Modified the `getAll` method to load an index file and use it to determine the paths of metadata files, instead of listing assets directly.

Dependency updates:

* [`app/article_viewer/pubspec.yaml`](diffhunk://#diff-959ce93fa3458658375c26554f01067df42dd2b171239309eb6a3aa29408e1d4R19-R21): Added a dependency on the `article_models` package.

Code imports:

* [`app/article_viewer/lib/data/repositories/article/article_meta_repository.dart`](diffhunk://#diff-1d1b6163ab55249553000ca96fc7bbcb562a2da07bcd1c13902f271a43ad01caR6): Added an import for the `article_models` package.